### PR TITLE
Added named import rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,28 +9,26 @@ module.exports = {
     'react'
   ],
   rules: {
-    'global-require': 0,
+    'import/named': 2,
 
     'react/prefer-stateless-function': 0,
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
     'react/react-in-jsx-scope': 2,
-
     'react/jsx-no-bind': 1,
+
+    'global-require': 0,
     'max-len': [1, 160, 2],
     'prefer-template': 1,
     'quote-props': 1,
     'arrow-body-style': 0,
     'prefer-arrow-callback': 1,
     'no-case-declarations': 1,
-
     'no-console': 0,
     'no-var': 0,
     'vars-on-top': 0,
     'comma-dangle': 0,
-
     'no-unused-vars': [2, {vars: 'all', args: 'none', varsIgnorePattern: '[iI]gnored'}],
-
     'no-undef': 2,
     'no-use-before-define': 0,
     'no-param-reassign': 0,


### PR DESCRIPTION
This rule errors if you import a named method that doesn't exist in the module - not sure why it's not turned on by default in airbnb spec but super useful for us.
