### PR TITLE
feature: explicitly disallow debugger statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ module.exports = {
     "no-unused-vars": "error",
     "no-duplicate-imports": "error",
     // Enforce that code is formatted with prettier.
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    // Explicitly disallow debugging statements
+    "no-debugger": "error"
   }
 };


### PR DESCRIPTION
This pull request updates the shared configuration so that `debugger` statements cause JavaScript linting to fail.

Fixes https://github.com/goabstract/JIRA/issues/6051