### PR TITLE
Enforce curly braces for all if statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "import/no-webpack-loader-syntax": "off",
     "import/order": "warn",
     "mocha/no-exclusive-tests": "error",
+    curly: ["error", "all"],
     // Prettier automatically uses the least amount of parens possible, so this
     // does more harm than good.
     "no-mixed-operators": "off",


### PR DESCRIPTION
Enables https://eslint.org/docs/rules/curly, which is auto fixable.

Came about from https://github.com/goabstract/ui/pull/661#discussion_r266635536, I'm interested to hear what others on the team think about this.

I like relying on prettier for any stylistic formatting, I see this as a kind of rule that I wish prettier didn't give as much flexibility on. And since this is an auto-fixable rule, I think we can view this as kind of an extension of prettier.