### PR TITLE
chore: add eslint-config-react-hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
   parser: "babel-eslint",
   extends: ["react-app", "plugin:import/errors", "plugin:import/warnings"],
   env: { browser: false },
-  plugins: ["mocha", "prettier"],
+  plugins: ["mocha", "react-hooks", "prettier"],
   rules: {
     // This doesn't work for us because we use `inject-loader` for testing JS
     // files, and can't be automatically configured in webpack.config.js.
@@ -19,6 +19,8 @@ module.exports = {
     // Explicitly disallow debugging statements
     "no-debugger": "error",
     // Disallow return await blah(); which is not needed outside of try/catch
-    "no-return-await": "error"
+    "no-return-await": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "prettier": "1.15.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "prettier": "1.15.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,11 @@ eslint-plugin-prettier@^3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
+  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
+
 eslint-plugin-react@7.x:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"


### PR DESCRIPTION
This PR adds [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) to our shared eslint config, which enforces the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html). 